### PR TITLE
Bug Fix: File Downloads

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -57,7 +57,8 @@ const getLocation = href => {
 const getDownloadFileName = (fname, url) => {
   // splits after the fifth occurence of '_'
   fname = fname.replace(/([^_]*_){5}/, "");
-  const filePrefix = fileRename[url] || "";
+  let filePrefix = fileRename[url] || "";
+  filePrefix = filePrefix.replace(/(\r\n|\n|\r)/gm, " ");
   const index = fname[0] === "_" ? 1 : 0;
   const title = filePrefix + fname.substr(index, fname.length);
   return title;


### PR DESCRIPTION
Recent update of VTOP, messed up download paths of course material.

Cause:
In new interface of course material in VTOP there is a line breaker in `Lecture Date`, which broke the extension to give valid file paths.

Fix:
Remove Line Breaks in File Names (Regex) 
  